### PR TITLE
feat: Emit all arguments when first argument is not a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ MIT
 [npm-image]: https://img.shields.io/npm/v/glogg.svg?style=flat-square
 
 [ci-url]: https://github.com/gulpjs/glogg/actions?query=workflow:dev
-[ci-image]: https://img.shields.io/github/workflow/status/gulpjs/glogg/dev?style=flat-square
+[ci-image]: https://img.shields.io/github/actions/workflow/status/gulpjs/glogg/dev.yml?style=flat-square
 
 [coveralls-url]: https://coveralls.io/r/gulpjs/glogg
 [coveralls-image]: https://img.shields.io/coveralls/gulpjs/glogg/master.svg?style=flat-square

--- a/README.md
+++ b/README.md
@@ -57,33 +57,41 @@ are passed through node's `util.format()` before being emitted. Other parts
 of a node program can get the logger by namespace and listen for the events to
 be emitted.
 
-#### logger.debug(msg)
+#### logger.debug(msg, ...args)
 
 Emits a `debug` event with the given `msg`.
 
 If the first argument is a string, all arguments are passed to node's
 `util.format()` before being emitted.
 
-#### logger.info(msg)
+If the first argument is not a string, all arguments will be emitted directly.
+
+#### logger.info(msg, ...args)
 
 Emits a `info` event with the given `msg`.
 
 If the first argument is a string, all arguments are passed to node's
 `util.format()` before being emitted.
 
-#### logger.warn(msg)
+If the first argument is not a string, all arguments will be emitted directly.
+
+#### logger.warn(msg, ...args)
 
 Emits a `warn` event with the given `msg`.
 
 If the first argument is a string, all arguments are passed to node's
 `util.format()` before being emitted.
 
-#### logger.error(msg)
+If the first argument is not a string, all arguments will be emitted directly.
+
+#### logger.error(msg, ...args)
 
 Emits a `error` event with the given `msg`.
 
 If the first argument is a string, all arguments are passed to node's
 `util.format()` before being emitted.
+
+If the first argument is not a string, all arguments will be emitted directly.
 
 **Note: You must handle this event in some way or the node process will crash
 when an `error` event is emitted.**

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function makeLogLevel(self, level) {
     if (typeof msg === 'string') {
       self.emit(level, format.apply(null, arguments));
     } else {
-      self.emit.apply(self, arguments);
+      self.emit.apply(self, Array.prototype.slice.call(arguments));
     }
   };
 }

--- a/index.js
+++ b/index.js
@@ -21,7 +21,8 @@ function makeLogLevel(self, level) {
     if (typeof msg === 'string') {
       self.emit(level, format.apply(null, arguments));
     } else {
-      self.emit.apply(self, Array.prototype.slice.call(arguments));
+      var args = Array.prototype.slice.call(arguments);
+      self.emit.apply(self, [level].concat(args));
     }
   };
 }

--- a/index.js
+++ b/index.js
@@ -19,10 +19,10 @@ function getLogger(namespace) {
 function makeLogLevel(self, level) {
   return function (msg) {
     if (typeof msg === 'string') {
-      msg = format.apply(null, arguments);
+      self.emit(level, format.apply(null, arguments));
+    } else {
+      self.emit.apply(self, arguments);
     }
-
-    self.emit(level, msg);
   };
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -73,6 +73,18 @@ describe('glogg', function () {
     logger.debug(expected);
   });
 
+  it('emits all arguments to the log if non-string message', function (done) {
+    var expected = { test: 'something' };
+
+    logger.on('debug', function (msg, extra) {
+      expect(msg).toEqual(expected);
+      expect(extra).toEqual(true);
+      done();
+    });
+
+    logger.debug(expected, true);
+  });
+
   it('allows you to "destructure" the individual log-level functions', function (done) {
     var debug = logger.debug;
 


### PR DESCRIPTION
This ensures arguments aren't lost when "logged" without a string message. This would allow for glogg and gulplog to support "logging" symbols plus extra data.