### PR TITLE
feat: Re-emit messages from legacy namespace on new namespace

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,14 +3,25 @@
 var format = require('util').format;
 
 var sparkles = require('sparkles');
+var legacySparkles = require('sparkles/legacy');
 
 var levels = ['debug', 'info', 'warn', 'error'];
 
 function getLogger(namespace) {
   var logger = sparkles(namespace);
+  var deprecatedLogger = legacySparkles(namespace);
 
   levels.forEach(function (level) {
     logger[level] = makeLogLevel(logger, level);
+
+    // Wire up listeners for every level on the deprecated namespace
+    // If anything gets emitted on this namespace, we'll emit the
+    // `deprecated` event and re-emit the event on the new logger
+    deprecatedLogger.on(level, function () {
+      logger.emit('deprecated');
+      var args = Array.prototype.slice.call(arguments);
+      logger[level].apply(logger, args);
+    });
   });
 
   return logger;

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "nyc mocha --async-only"
   },
   "dependencies": {
-    "sparkles": "^2.0.0"
+    "sparkles": "^2.1.0"
   },
   "devDependencies": {
     "eslint": "^7.32.0",

--- a/test/index.js
+++ b/test/index.js
@@ -2,6 +2,8 @@
 
 var expect = require('expect');
 
+var sparklesLegacy = require('sparkles/legacy');
+
 var glogg = require('../');
 
 describe('glogg', function () {
@@ -94,5 +96,83 @@ describe('glogg', function () {
     });
 
     debug('test');
+  });
+});
+
+describe('events on legacy namespace', function () {
+  var logger;
+  var legacy;
+
+  beforeEach(function (done) {
+    var namespace = 'glogg-test';
+    logger = glogg(namespace);
+    legacy = sparklesLegacy(namespace);
+    done();
+  });
+
+  afterEach(function (done) {
+    logger.remove();
+    legacy.remove();
+    done();
+  });
+
+  it('emits deprecated event and forwards debug to logger', function (done) {
+    var deprecated = false;
+    logger.on('deprecated', function () {
+      deprecated = true;
+    });
+
+    logger.on('debug', function (msg) {
+      expect(deprecated).toEqual(true);
+      expect(msg).toEqual('test');
+      done();
+    });
+
+    legacy.emit('debug', 'test');
+  });
+
+  it('emits deprecated event and forwards info to logger', function (done) {
+    var deprecated = false;
+    logger.on('deprecated', function () {
+      deprecated = true;
+    });
+
+    logger.on('info', function (msg) {
+      expect(deprecated).toEqual(true);
+      expect(msg).toEqual('test');
+      done();
+    });
+
+    legacy.emit('info', 'test');
+  });
+
+  it('emits deprecated event and forwards warn to logger', function (done) {
+    var deprecated = false;
+    logger.on('deprecated', function () {
+      deprecated = true;
+    });
+
+    logger.on('warn', function (msg) {
+      expect(deprecated).toEqual(true);
+      expect(msg).toEqual('test');
+      done();
+    });
+
+    legacy.emit('warn', 'test');
+  });
+
+  it('emits deprecated event and forwards error to logger', function (done) {
+    var deprecated = false;
+    logger.on('deprecated', function () {
+      deprecated = true;
+    });
+
+    logger.on('error', function (msg) {
+      expect(deprecated).toEqual(true);
+      expect(msg).toEqual('test');
+      done();
+    });
+
+    legacy.emit('error', 'test');
   });
 });


### PR DESCRIPTION
In v2 of sparkles, we switched to using a symbol to attach our event emitter to the global. This leads to blackholing of messages if we don't listen to the old emitter. In this PR, I'm consuming a new `legacy` module from our sparkles package to listen for messages on the old namespace. If a message is received, a `deprecated` event is emitted that a consumer can listen to and show a message. Then, the message is re-emitted on the new logger namespace.

This will help us with https://github.com/gulpjs/gulp-cli/issues/249